### PR TITLE
Add `f-` mixin for new HeadlineSans font

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.3.0 (2014-05-12)
+
+- [new] `headline-sans` font, with associated `f-headline` mixin
+
 ## 1.2.0 (2014-04-22)
 
 - [new] `get-font-size()` function

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ $sans-serif: "AgateSans", "Helvetica Neue", Helvetica, Arial, "Lucida Grande", s
 $serif: "EgyptianText", georgia, serif;
 $serifheadline: "EgyptianHeadline", georgia, serif;
 $text-sans: "TextSans", "Helvetica Neue", Helvetica, Arial, "Lucida Grande", sans-serif;
+$headline-sans: "HeadlineSans", "Helvetica Neue", Helvetica, Arial, "Lucida Grande", sans-serif;
 
 $fs-headers: (
     16 20, // 1
@@ -73,3 +74,7 @@ $fs-textsans: (
 Provides Sass mixins and values for the Guardian typography & font scale.
 
 ![Font scale](font-scale.png)
+
+### NB
+
+`HeadlineSans` is not currently integrated into our font scale, hence no `fs-` mixin; currently we're just using it as a replacement font in a few places.

--- a/_font-scale.scss
+++ b/_font-scale.scss
@@ -9,6 +9,7 @@ $sans-serif: "AgateSans", "Helvetica Neue", Helvetica, Arial, "Lucida Grande", s
 $serif: "EgyptianText", georgia, serif !default;
 $serifheadline: "EgyptianHeadline", georgia, serif !default;
 $text-sans: "TextSans", "Helvetica Neue", Helvetica, Arial, "Lucida Grande", sans-serif !default;
+$headline-sans: "HeadlineSans", "Helvetica Neue", Helvetica, Arial, "Lucida Grande", sans-serif !default;
 
 // Font scale
 // font-size (px) line-height (px) // level
@@ -152,4 +153,10 @@ $fs-textsans: (
     @if $size-only == false {
         @include f-textsans;
     }
+}
+
+@mixin f-headlineSans {
+    font-family: $headline-sans;
+    font-weight: 200;
+    -webkit-font-smoothing: antialiased;
 }


### PR DESCRIPTION
Just the font mixin, as not in enough usage to warrant being on the scale
