### PR TITLE
Use normal font-weight for headlineSans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.2 (2014-08-18)
+
+- [Update] Change `f-headlineSans` to `font-weight: normal`
+
 ## 2.0.1 (2014-08-14)
 
 - [Update] Change default line-height of `fs-header(3)`

--- a/_typography.mixins.scss
+++ b/_typography.mixins.scss
@@ -146,5 +146,4 @@
 
 @mixin f-headlineSans {
     font-family: $f-sans-serif-headline;
-    font-weight: 200;
 }

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "guss-typography",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "main": [
        "_typography.config.scss",
        "_typography.helpers.scss",


### PR DESCRIPTION
Fixes https://github.com/guardian/guss-typography/issues/11
