### PR TITLE
Deprecate use of rem units, output pixels only

### DIFF
--- a/_typography.mixins.scss
+++ b/_typography.mixins.scss
@@ -36,10 +36,8 @@
 // @include font-size(18, 24);
 
 @mixin font-size($size, $line-height: $size) {
-    @include rem((
-        font-size: $size,
-        line-height: $line-height
-    ));
+    font-size: $size;
+    line-height: $line-height;
 }
 
 // Font styling shorthand

--- a/bower.json
+++ b/bower.json
@@ -1,12 +1,9 @@
 {
   "name": "guss-typography",
   "main": [
-       "_typography.config.scss",
-       "_typography.helpers.scss",
-       "_typography.mixins.scss",
-       "_typography.scss"
-  ],
-  "dependencies": {
-    "guss-rem": "~1"
-  }
+     "_typography.config.scss",
+     "_typography.helpers.scss",
+     "_typography.mixins.scss",
+     "_typography.scss"
+  ]
 }


### PR DESCRIPTION
Not sure about this one.

In the frontend project, it will spare hundreds of calls to the `rem` mixin.

Makes sense for NGW but does would it be helpful for other products?

![ ](http://media.giphy.com/media/a8eIdceSm5L9u/giphy.gif)
