### PR TITLE
V3 - fixes #7

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,57 +16,53 @@ $f-serif-headline: 'Guardian Egyptian Web', Georgia, serif;
 $f-sans-serif-text: 'Guardian Text Sans Web', 'Helvetica Neue', Helvetica, Arial, 'Lucida Grande', sans-serif;
 $f-sans-serif-headline: 'Guardian Sans Web', 'Helvetica Neue', Helvetica, Arial, 'Lucida Grande', sans-serif;
 
-$fs-headers: (
-    16 20, // 1
-    18 24, // 2
-    20 24, // 3
-    22 28, // 4
-    24 28, // 5
+$font-scale: (
+    header: (
+        1: (font-size: 16, line-height: 20),
+        2: (font-size: 18, line-height: 24),
+        3: (font-size: 20, line-height: 24),
+        4: (font-size: 22, line-height: 28),
+        5: (font-size: 24, line-height: 28),
+    ),
+    headline: (
+        1: (font-size: 14, line-height: 18),
+        2: (font-size: 16, line-height: 20),
+        3: (font-size: 20, line-height: 24),
+        4: (font-size: 24, line-height: 28),
+        5: (font-size: 28, line-height: 32),
+        6: (font-size: 32, line-height: 36),
+        7: (font-size: 36, line-height: 40),
+        8: (font-size: 40, line-height: 44),
+        9: (font-size: 44, line-height: 48),
+    ),
+    bodyHeading: (
+        1: (font-size: 14, line-height: 22),
+        2: (font-size: 16, line-height: 24),
+        3: (font-size: 18, line-height: 28),
+        4: (font-size: 20, line-height: 28),
+    ),
+    bodyCopy: (
+        1: (font-size: 14, line-height: 20),
+        2: (font-size: 16, line-height: 24),
+        3: (font-size: 18, line-height: 28),
+    ),
+    data: (
+        1: (font-size: 11, line-height: 14),
+        2: (font-size: 12, line-height: 14),
+        3: (font-size: 13, line-height: 16),
+        4: (font-size: 14, line-height: 18),
+        5: (font-size: 16, line-height: 20),
+        6: (font-size: 18, line-height: 22),
+    ),
+    textSans: (
+        1: (font-size: 12, line-height: 16),
+        2: (font-size: 13, line-height: 18),
+        3: (font-size: 14, line-height: 20),
+        4: (font-size: 14, line-height: 22),
+    )
 );
 
-$fs-headlines: (
-    14 18, // 1
-    16 20, // 2
-    20 24, // 3
-    24 28, // 4
-    28 32, // 5
-    32 36, // 6
-    36 40, // 7
-    40 44, // 8
-    44 48, // 9
-);
-
-$fs-bodyHeadings: (
-    14 22, // 1
-    16 24, // 2
-    18 28, // 3
-    20 28, // 4
-);
-
-$fs-bodyCopy: (
-    14 20, // 1
-    16 24, // 2
-    18 28, // 3
-);
-
-$fs-data: (
-    11 14, // 1
-    12 14, // 2
-    13 16, // 3
-    14 18, // 4
-    16 20, // 5
-    18 22, // 6
-);
-
-$fs-textSans: (
-    12 16, // 1
-    13 18, // 2
-    14 20, // 3
-    14 22, // 4
-);
-
-@import 'path/to/_helpers.scss';
-@import 'path/to/_font-scale.scss';
+@import 'path/to/_typography.scss';
 ```
 
 ## Suggested default type settings
@@ -123,4 +119,4 @@ Provides Sass mixins and values for the Guardian typography & font scale.
 
 ### Nota Bene
 
-`Guardian Sans Web` is not currently integrated into our font scale, hence no `fs-` mixin; currently we're just using it as a replacement font in a few places.
+`Guardian Sans Web` is not currently integrated into our font scale matrix, hence no `fs-` mixin; currently we're just using it as a replacement font in a few places.

--- a/README.md
+++ b/README.md
@@ -109,6 +109,12 @@ p {
     // Output font family and weight settings only
     @include f-bodyHeading;
 }
+.get-font-size {
+    font-size: get-font-size(headline, 6);
+}
+.get-line-height {
+    line-height: get-line-height(header, 3);
+}
 ```
 
 ## Features

--- a/_typography.config.scss
+++ b/_typography.config.scss
@@ -1,64 +1,86 @@
-// Fonts
-// =============================================================================
-
+/**
+ * Data font stack
+ *
+ * @group typography
+ */
 $f-data: 'Guardian Agate Sans 1 Web', 'Helvetica Neue', Helvetica, Arial, 'Lucida Grande', sans-serif !default;
+
+/**
+ * Serif font stack
+ *
+ * @group typography
+ */
 $f-serif-text: 'Guardian Text Egyptian Web', Georgia, serif !default;
+
+/**
+ * Headline font stack
+ *
+ * @group typography
+ */
 $f-serif-headline: 'Guardian Egyptian Web', Georgia, serif !default;
+
+/**
+ * Sans serif text font stack
+ *
+ * @group typography
+ */
 $f-sans-serif-text: 'Guardian Text Sans Web', 'Helvetica Neue', Helvetica, Arial, 'Lucida Grande', sans-serif !default;
+
+/**
+ * Sans serif headline font stack
+ *
+ * @group typography
+ */
 $f-sans-serif-headline: 'Guardian Sans Web', 'Helvetica Neue', Helvetica, Arial, 'Lucida Grande', sans-serif !default;
 
-
-// Font scale
-// =============================================================================
-
-// font-size (px) line-height (px) // level
-// See font-scale.png and font-scale.html for a correspondance matrix
-
-$fs-headers: (
-    16 20, // 1
-    18 24, // 2
-    20 24, // 3
-    22 28, // 4
-    24 28, // 5
-) !default;
-
-$fs-headlines: (
-    14 18, // 1
-    16 20, // 2
-    20 24, // 3
-    24 28, // 4
-    28 32, // 5
-    32 36, // 6
-    36 40, // 7
-    40 44, // 8
-    44 48, // 9
-) !default;
-
-$fs-bodyHeadings: (
-    14 22, // 1
-    16 24, // 2
-    18 28, // 3
-    20 28, // 4
-) !default;
-
-$fs-bodyCopy: (
-    14 20, // 1
-    16 24, // 2
-    18 28, // 3
-) !default;
-
-$fs-data: (
-    11 14, // 1
-    12 14, // 2
-    13 16, // 3
-    14 18, // 4
-    16 20, // 5
-    18 22, // 6
-) !default;
-
-$fs-textSans: (
-    12 16, // 1
-    13 18, // 2
-    14 20, // 3
-    14 22, // 4
+/**
+ * Default font scale settings
+ * See font-scale.html and font-scale.png for visual representations
+ *
+ * @group typography
+ */
+$font-scale: (
+    header: (
+        1: (font-size: 16, line-height: 20),
+        2: (font-size: 18, line-height: 24),
+        3: (font-size: 20, line-height: 24),
+        4: (font-size: 22, line-height: 28),
+        5: (font-size: 24, line-height: 28),
+    ),
+    headline: (
+        1: (font-size: 14, line-height: 18),
+        2: (font-size: 16, line-height: 20),
+        3: (font-size: 20, line-height: 24),
+        4: (font-size: 24, line-height: 28),
+        5: (font-size: 28, line-height: 32),
+        6: (font-size: 32, line-height: 36),
+        7: (font-size: 36, line-height: 40),
+        8: (font-size: 40, line-height: 44),
+        9: (font-size: 44, line-height: 48),
+    ),
+    bodyHeading: (
+        1: (font-size: 14, line-height: 22),
+        2: (font-size: 16, line-height: 24),
+        3: (font-size: 18, line-height: 28),
+        4: (font-size: 20, line-height: 28),
+    ),
+    bodyCopy: (
+        1: (font-size: 14, line-height: 20),
+        2: (font-size: 16, line-height: 24),
+        3: (font-size: 18, line-height: 28),
+    ),
+    data: (
+        1: (font-size: 11, line-height: 14),
+        2: (font-size: 12, line-height: 14),
+        3: (font-size: 13, line-height: 16),
+        4: (font-size: 14, line-height: 18),
+        5: (font-size: 16, line-height: 20),
+        6: (font-size: 18, line-height: 22),
+    ),
+    textSans: (
+        1: (font-size: 12, line-height: 16),
+        2: (font-size: 13, line-height: 18),
+        3: (font-size: 14, line-height: 20),
+        4: (font-size: 14, line-height: 22),
+    )
 ) !default;

--- a/_typography.helpers.scss
+++ b/_typography.helpers.scss
@@ -1,45 +1,102 @@
 // Font scale helpers
 // =============================================================================
 
-// Get a font-size from the font-scale matrix
-//
-// @param {List} $font-scale - One of the $fs- lists
-// @param {Number} $level - ID in the font-scale matrix (eg: 1 for Header 1)
-//
-// @example
-// font-size: get-font-size($fs-header, 3);
-//
-// @return {Number}
-
-@function get-font-size($font-scale, $level) {
-    @return convert-to-px(nth(nth($font-scale, $level), 1));
+/**
+ * Grab all levels of a font the font-scale
+ *
+ * @param {String} $name - Name of the font-scale matrix (eg: headline)
+ * @param {Map} $font-scale ($font-scale)
+ * 
+ * @example
+ *  font-size: get-scale(header);
+ *
+ * @requires {variable} $font-scale
+ *
+ * @return {Map}
+ *
+ * @group typography
+ */
+@function get-scale($name, $font-scale: $font-scale) {
+    @return map-get($font-scale, $name);
 }
 
-
-// Get a line-height from the font-scale matrix
-//
-// @param {List} $font-scale - One of the $fs- lists
-// @param {Number} $level - ID in the font-scale matrix (eg: 1 for Header 1)
-//
-// @example
-// font-size: get-line-height($fs-header, 3);
-//
-// @return {Number}
-
-@function get-line-height($font-scale, $level) {
-    @return convert-to-px(nth(nth($font-scale, $level), 2));
+/**
+ * Grab info for a particular level of a font-scale
+ *
+ * @param {String} $name - Name of the font-scale in the matrix (eg: headline)
+ * @param {Number} $level - Level in the matrix
+ * @param {Map} $font-scale ($font-scale)
+ * 
+ * @example
+ *  font-size: get-scale-level(header, 1);
+ *
+ * @requires {variable} $font-scale
+ * @requires {function} get-scale
+ *
+ * @return {Map}
+ *
+ * @group typography
+ */
+@function get-scale-level($name, $level, $font-scale: $font-scale) {
+    @return map-get(get-scale($name, $font-scale), $level);
 }
 
+/**
+ * Get a font-size for a level in the font-scale matrix
+ *
+ * @param {String} $name - Name of the font-scale in the matrix (eg: headline)
+ * @param {Number} $level - Level in the matrix
+ * @param {Map} $font-scale - Configuration
+ * 
+ * @example
+ *  font-size: get-font-size(header, 3);
+ *
+ * @requires {variable} $font-scale
+ * @requires {function} convert-to-px
+ * @requires {function} get-scale-level
+ * 
+ * @return {Number}
+ *
+ * @group typography
+ */
+@function get-font-size($name, $level, $font-scale: $font-scale) {
+    @return convert-to-px(map-get(get-scale-level($name, $level, $font-scale), font-size));
+}
 
-// Turn any value into pixels
-//
-// @param {Number} $value
-//
-// @example
-// font-size: convert-to-px(14); // 14px
-//
-// @return {Number}
+/**
+ * Get a line-height for a level in the font-scale matrix
+ *
+ * @param {String} $name - Name of the font-scale in the matrix (eg: headline)
+ * @param {Number} $level - Level in the matrix
+ * @param {Map} $font-scale - Configuration
+ *
+ * @example
+ *  font-size: get-line-height(header, 3);
+ *
+ * @requires {variable} $font-scale
+ * @requires {function} convert-to-px
+ * @requires {function} get-scale-level
+ *
+ * @return {Number}
+ *
+ * @group typography
+ */
+@function get-line-height($name, $level, $font-scale: $font-scale) {
+    @return convert-to-px(map-get(get-scale-level($name, $level, $font-scale), line-height));
+}
 
+/**
+ * Turn any value into pixels
+ *
+ * @param {Number} $value
+ *
+ * @example
+ *  font-size: convert-to-px(14); // 14px
+ *
+ * @return {Number}
+ *
+ * @group typography
+ */
 @function convert-to-px($value) {
     @if (type-of($value) == number and $value != 0) {
         $value: if(unitless($value), $value * 1px, $value);

--- a/_typography.helpers.scss
+++ b/_typography.helpers.scss
@@ -6,7 +6,7 @@
  *
  * @param {String} $name - Name of the font-scale matrix (eg: headline)
  * @param {Map} $font-scale ($font-scale)
- * 
+ *
  * @example
  *  font-size: get-scale(header);
  *
@@ -26,7 +26,7 @@
  * @param {String} $name - Name of the font-scale in the matrix (eg: headline)
  * @param {Number} $level - Level in the matrix
  * @param {Map} $font-scale ($font-scale)
- * 
+ *
  * @example
  *  font-size: get-scale-level(header, 1);
  *
@@ -47,14 +47,14 @@
  * @param {String} $name - Name of the font-scale in the matrix (eg: headline)
  * @param {Number} $level - Level in the matrix
  * @param {Map} $font-scale - Configuration
- * 
+ *
  * @example
  *  font-size: get-font-size(header, 3);
  *
  * @requires {variable} $font-scale
  * @requires {function} convert-to-px
  * @requires {function} get-scale-level
- * 
+ *
  * @return {Number}
  *
  * @group typography

--- a/_typography.mixins.scss
+++ b/_typography.mixins.scss
@@ -5,7 +5,7 @@
  * Default typography settings, to be included as soon as possible in the HTML
  * 1. Make type rendering look crisper
  * 2. Set baseline font size to 10px
- * 3. Fixes an IE11 bug where rouding with % would create scaling issues
+ * 3. Fixes an IE11 bug where rouding with % would create scaling issues  
  *    See http://bit.ly/1g4X0bX — thanks @7studio and @dawitti
  * 4. Set default text size back to 16px (at default zoom level)
  * 5. Set relative line spacing to 1.5 (16px * 1.5 = 24px)
@@ -55,9 +55,9 @@
 }
 
 /**
- * Font styling shorthand
+ * Font styling shorthand  
  * Note: prefer the usage of the font-scale mixins to stick to the font scale
- * 
+ *
  * @param {String} $family
  * @param {String} $weight
  * @param {Number} $size
@@ -84,10 +84,38 @@
 // f- stands for Font: use to set a font-family only
 // fs- for Font Scale: documented in font-scale.png
 
+/**
+ * Header family and weight properties.
+ *
+ * @requires {variable} $f-serif-headline
+ *
+ * @group typography
+ */
 @mixin f-header {
     font-family: $f-serif-headline;
     font-weight: 900;
 }
+
+/**
+ * Header typography settings.
+ *
+ * @param {Number} $level
+ * @param {Boolean} $size-only
+ *
+ * @example
+ *  // Output all properties (font-size, line-height, family, weight)
+ *  @include fs-header(3);
+ *  
+ *  // Output font-size and line-height only
+ *  @include fs-header(3, $size-only: true);
+ *
+ * @requires {function} get-font-size
+ * @requires {function} get-line-height
+ * @requires {mixin} font-size
+ * @requires {mixin} f-header
+ *
+ * @group typography
+ */
 @mixin fs-header($level, $size-only: false) {
     @include font-size(get-font-size(header, $level), get-line-height(header, $level));
 
@@ -96,10 +124,38 @@
     }
 }
 
+/**
+ * Healdine family and weight properties.
+ *
+ * @requires {variable} $f-serif-headline
+ *
+ * @group typography
+ */
 @mixin f-headline {
     font-family: $f-serif-headline;
     font-weight: normal;
 }
+
+/**
+ * Headline typography settings.
+ *
+ * @param {Number} $level
+ * @param {Boolean} $size-only
+ *
+ * @example
+ *  // Output all properties (font-size, line-height, family, weight)
+ *  @include fs-headline(3);
+ *  
+ *  // Output font-size and line-height only
+ *  @include fs-headline(3, $size-only: true);
+ *
+ * @requires {function} get-font-size
+ * @requires {function} get-line-height
+ * @requires {mixin} font-size
+ * @requires {mixin} f-headline
+ *
+ * @group typography
+ */
 @mixin fs-headline($level, $size-only: false) {
     @include font-size(get-font-size(headline, $level), get-line-height(headline, $level));
 
@@ -108,10 +164,38 @@
     }
 }
 
+/**
+ * Body Heading family and weight properties.
+ *
+ * @requires {variable} $f-serif-text
+ *
+ * @group typography
+ */
 @mixin f-bodyHeading {
     font-family: $f-serif-text;
     font-weight: bold;
 }
+
+/**
+ * Body Heading typography settings.
+ *
+ * @param {Number} $level
+ * @param {Boolean} $size-only
+ *
+ * @example
+ *  // Output all properties (font-size, line-height, family, weight)
+ *  @include fs-bodyHeading(3);
+ *  
+ *  // Output font-size and line-height only
+ *  @include fs-bodyHeading(3, $size-only: true);
+ *
+ * @requires {function} get-font-size
+ * @requires {function} get-line-height
+ * @requires {mixin} font-size
+ * @requires {mixin} f-bodyHeading
+ *
+ * @group typography
+ */
 @mixin fs-bodyHeading($level, $size-only: false) {
     @include font-size(get-font-size(bodyHeading, $level), get-line-height(bodyHeading, $level));
 
@@ -120,9 +204,37 @@
     }
 }
 
+/**
+ * Body Copy family property.
+ *
+ * @requires {variable} $f-serif-text
+ *
+ * @group typography
+ */
 @mixin f-bodyCopy {
     font-family: $f-serif-text;
 }
+
+/**
+ * Body Copy typography settings.
+ *
+ * @param {Number} $level
+ * @param {Boolean} $size-only
+ *
+ * @example
+ *  // Output all properties (font-size, line-height, family)
+ *  @include fs-bodyCopy(3);
+ *  
+ *  // Output font-size and line-height only
+ *  @include fs-bodyCopy(3, $size-only: true);
+ *
+ * @requires {function} get-font-size
+ * @requires {function} get-line-height
+ * @requires {mixin} font-size
+ * @requires {mixin} f-bodyCopy
+ *
+ * @group typography
+ */
 @mixin fs-bodyCopy($level, $size-only: false) {
     @include font-size(get-font-size(bodyCopy, $level), get-line-height(bodyCopy, $level));
 
@@ -131,9 +243,37 @@
     }
 }
 
+/**
+ * Data family property.
+ *
+ * @requires {variable} $f-data
+ *
+ * @group typography
+ */
 @mixin f-data {
     font-family: $f-data;
 }
+
+/**
+ * Data typography settings.
+ *
+ * @param {Number} $level
+ * @param {Boolean} $size-only
+ *
+ * @example
+ *  // Output all properties (font-size, line-height, family)
+ *  @include fs-data(3);
+ *  
+ *  // Output font-size and line-height only
+ *  @include fs-data(3, $size-only: true);
+ *
+ * @requires {function} get-font-size
+ * @requires {function} get-line-height
+ * @requires {mixin} font-size
+ * @requires {mixin} f-data
+ *
+ * @group typography
+ */
 @mixin fs-data($level, $size-only: false) {
     @include font-size(get-font-size(data, $level), get-line-height(data, $level));
 
@@ -142,9 +282,37 @@
     }
 }
 
+/**
+ * Text Sans family property.
+ *
+ * @requires {variable} $f-sans-serif-text
+ *
+ * @group typography
+ */
 @mixin f-textSans {
     font-family: $f-sans-serif-text;
 }
+
+/**
+ * Text Sans typography settings.
+ *
+ * @param {Number} $level
+ * @param {Boolean} $size-only
+ *
+ * @example
+ *  // Output all properties (font-size, line-height, family)
+ *  @include fs-textSans(3);
+ *  
+ *  // Output font-size and line-height only
+ *  @include fs-textSans(3, $size-only: true);
+ *
+ * @requires {function} get-font-size
+ * @requires {function} get-line-height
+ * @requires {mixin} font-size
+ * @requires {mixin} f-textSans
+ *
+ * @group typography
+ */
 @mixin fs-textSans($level, $size-only: false) {
     @include font-size(get-font-size(textSans, $level), get-line-height(textSans, $level));
 
@@ -153,6 +321,16 @@
     }
 }
 
+/**
+ * Headline Sans family property.  
+ * Is not currently integrated into our font scale matrix,
+ * hence no `fs-` mixin; currently we're just using it as a
+ * replacement font in a few places.
+ *
+ * @requires {variable} $f-sans-serif-headline
+ *
+ * @group typography
+ */
 @mixin f-headlineSans {
     font-family: $f-sans-serif-headline;
 }

--- a/_typography.mixins.scss
+++ b/_typography.mixins.scss
@@ -1,25 +1,33 @@
 // Default type settings
 // =============================================================================
 
-@mixin guss-typography-defaults {
+/**
+ * Default typography settings, to be included as soon as possible in the HTML
+ * 1. Make type rendering look crisper
+ * 2. Set baseline font size to 10px
+ * 3. Fixes an IE11 bug where rouding with % would create scaling issues
+ *    See http://bit.ly/1g4X0bX — thanks @7studio and @dawitti
+ * 4. Set default text size back to 16px (at default zoom level)
+ * 5. Set relative line spacing to 1.5 (16px * 1.5 = 24px)
+ *
+ * @param {String} $font-family ($f-serif-text) - Default global font
+ *
+ * @requires {variable} $f-serif-text
+ *
+ * @group typography
+ */
+@mixin guss-typography-defaults($font-family: $f-serif-text) {
     @at-root {
         html {
-            font-family: $f-serif-text;
-            // Make type rendering look crisper
-            -moz-osx-font-smoothing: grayscale;
-            -webkit-font-smoothing: antialiased;
-
-            // Set baseline font size to 10px
-            // This is used as a baseline for rem (root ems) values
-            font-size: 62.5%;
-
-            // For IE11 to do the math properly
-            // See http://bit.ly/1g4X0bX — thanks @7studio and @dawitti
-            font-size: calc(1em * .625);
+            font-family: $font-family;
+            -moz-osx-font-smoothing: grayscale; /* 1 */
+            -webkit-font-smoothing: antialiased; /* 1 */
+            font-size: 62.5%; /* 2 */
+            font-size: calc(1em * .625); /* 3 */
         }
         body {
-            font-size: 1.6em; // Bump font-size back up to 16px
-            line-height: 1.5;
+            font-size: 1.6em; /* 4 */
+            line-height: 1.5; /* 5 */
         }
     }
 }
@@ -28,25 +36,40 @@
 // Shorthands for font declarations
 // =============================================================================
 
-// Tests: http://sassmeister.com/gist/7990898
-
-// Accessible font-size and line-height with a pixel fallback
-//
-// @example
-// @include font-size(18, 24);
-
+/**
+ * Font-size and line-height shorthand
+ *
+ * @param {Number} $size
+ * @param {Number} $line-height ($size)
+ *
+ * @example
+ *  @include font-size(18, 24);
+ *
+ * @requires {function} convert-to-px
+ *
+ * @group typography
+ */
 @mixin font-size($size, $line-height: $size) {
     font-size: convert-to-px($size);
     line-height: convert-to-px($line-height);
 }
 
-// Font styling shorthand
-//
-// @example
-// @include font(arial, bold, 18, 24);
-//
-// Note: prefer the usage of the font-scale mixins
-
+/**
+ * Font styling shorthand
+ * Note: prefer the usage of the font-scale mixins to stick to the font scale
+ * 
+ * @param {String} $family
+ * @param {String} $weight
+ * @param {Number} $size
+ * @param {Number} $line-height ($size)
+ *
+ * @example
+ *  @include font(arial, bold, 18, 24);
+ *
+ * @requires {mixin} font-size
+ *
+ * @group typography
+ */
 @mixin font($family, $weight, $size, $line-height: $size) {
     font-family: $family;
     font-weight: $weight;
@@ -66,9 +89,7 @@
     font-weight: 900;
 }
 @mixin fs-header($level, $size-only: false) {
-    $header: nth($fs-headers, $level);
-
-    @include font-size(nth($header, 1), nth($header, 2));
+    @include font-size(get-font-size(header, $level), get-line-height(header, $level));
 
     @if $size-only == false {
         @include f-header;
@@ -80,9 +101,7 @@
     font-weight: normal;
 }
 @mixin fs-headline($level, $size-only: false) {
-    $headline: nth($fs-headlines, $level);
-
-    @include font-size(nth($headline, 1), nth($headline, 2));
+    @include font-size(get-font-size(headline, $level), get-line-height(headline, $level));
 
     @if $size-only == false {
         @include f-headline;
@@ -94,9 +113,7 @@
     font-weight: bold;
 }
 @mixin fs-bodyHeading($level, $size-only: false) {
-    $heading: nth($fs-bodyHeadings, $level);
-
-    @include font-size(nth($heading, 1), nth($heading, 2));
+    @include font-size(get-font-size(bodyHeading, $level), get-line-height(bodyHeading, $level));
 
     @if $size-only == false {
         @include f-bodyHeading;
@@ -107,9 +124,7 @@
     font-family: $f-serif-text;
 }
 @mixin fs-bodyCopy($level, $size-only: false) {
-    $bodycopy: nth($fs-bodyCopy, $level);
-
-    @include font-size(nth($bodycopy, 1), nth($bodycopy, 2));
+    @include font-size(get-font-size(bodyCopy, $level), get-line-height(bodyCopy, $level));
 
     @if $size-only == false {
         @include f-bodyCopy;
@@ -120,9 +135,7 @@
     font-family: $f-data;
 }
 @mixin fs-data($level, $size-only: false) {
-    $data: nth($fs-data, $level);
-
-    @include font-size(nth($data, 1), nth($data, 2));
+    @include font-size(get-font-size(data, $level), get-line-height(data, $level));
 
     @if $size-only == false {
         @include f-data;
@@ -133,9 +146,7 @@
     font-family: $f-sans-serif-text;
 }
 @mixin fs-textSans($level, $size-only: false) {
-    $textsans: nth($fs-textSans, $level);
-
-    @include font-size(nth($textsans, 1), nth($textsans, 2));
+    @include font-size(get-font-size(textSans, $level), get-line-height(textSans, $level));
 
     @if $size-only == false {
         @include f-textSans;


### PR DESCRIPTION
### SassDoc

Inline documentation uses [SassDoc](https://github.com/SassDoc/sassdoc) notation, to do things like this:

![screen shot 2014-08-26 at 18 06 20](https://cloud.githubusercontent.com/assets/85783/4048423/598c2562-2d43-11e4-8bbb-9ae24a554e6f.PNG)
### Configuration

Configuration is consolidated into a single map, easy to extend and simpler to query:

``` scss
$font-scale: (
    header: (
        1: (font-size: 16, line-height: 20),
        2: (font-size: 18, line-height: 24),
        3: (font-size: 20, line-height: 24),
        4: (font-size: 22, line-height: 28),
        5: (font-size: 24, line-height: 28),
    ),
    headline: (
        1: (font-size: 14, line-height: 18),
        2: (font-size: 16, line-height: 20),
        3: (font-size: 20, line-height: 24),
        4: (font-size: 24, line-height: 28),
        5: (font-size: 28, line-height: 32),
        6: (font-size: 32, line-height: 36),
        7: (font-size: 36, line-height: 40),
        8: (font-size: 40, line-height: 44),
        9: (font-size: 44, line-height: 48),
    ),
    bodyHeading: (
        1: (font-size: 14, line-height: 22),
        2: (font-size: 16, line-height: 24),
        3: (font-size: 18, line-height: 28),
        4: (font-size: 20, line-height: 28),
    ),
    bodyCopy: (
        1: (font-size: 14, line-height: 20),
        2: (font-size: 16, line-height: 24),
        3: (font-size: 18, line-height: 28),
    ),
    data: (
        1: (font-size: 11, line-height: 14),
        2: (font-size: 12, line-height: 14),
        3: (font-size: 13, line-height: 16),
        4: (font-size: 14, line-height: 18),
        5: (font-size: 16, line-height: 20),
        6: (font-size: 18, line-height: 22),
    ),
    textSans: (
        1: (font-size: 12, line-height: 16),
        2: (font-size: 13, line-height: 18),
        3: (font-size: 14, line-height: 20),
        4: (font-size: 14, line-height: 22),
    )
);
```
### Helpers

Ubiquity between configuration, the png matrix and the helper parameter syntax.

`get-font-size` and `get-line-height` helpers take these two parameters:

``` scss
@param {String} $name - Name of the font-scale in the matrix (eg: headline)
@param {Number} $level - Level in the matrix
```

They should be called like this:

``` scss
.get-font-size {
    font-size: get-font-size(headline, 6); // used to be ($fs-headlines, 6)
}
.get-line-height {
    line-height: get-line-height(header, 3); // used to be ($fs-headers, 3)
}
```

![ ](http://gifs.joelglovier.com/smooth/bill-murray-toast.gif)
